### PR TITLE
Add missing pyscard and cleanup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# to use this, install [direnv](https://direnv.net/)
+source venv/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: standard-tests vendor-tests
+
+standard-tests: venv
+	venv/bin/pytest tests/standard
+
+vendor-tests: venv
+	venv/bin/pytest tests/vendor
+
+# setup development environment
+venv:
+	python3 -m venv venv
+	venv/bin/pip install -U pip
+	venv/bin/pip install -U -r requirements.txt
+
+# re-run if  dependencies change
+update:
+	venv/bin/pip install -U pip
+	venv/bin/pip install -U -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -2,27 +2,26 @@
 
 Test suite for FIDO2, U2F, and other security key functions
 
-# Installation
+# Setup
 
 Need python 3.6+.
 
+`make venv` and `source venv/bin/activate`
 
-```
-pip3 install -r requirements.txt
-```
+Or simply `pip3 install --user -r requirements.txt`
 
 # Running the tests
 
-Run all FIDO2, U2F, and HID tests.
+Run all FIDO2, U2F, and HID tests:
 
 ```
-python -m pytest tests/standard
+pytest tests/standard
 ```
 
-Run vendor/model specific tests.
+Run vendor/model specific tests:
 
 ```
-python -m pytest tests/vendor
+pytest tests/vendor
 ```
 
 # Running against simulation
@@ -30,7 +29,6 @@ python -m pytest tests/vendor
 To run tests against a "simulation" build of the Solo authenticator, supply the `--sim` option.
 
 ```
-python -m pytest tests/standard --sim
+pytest --sim tests/standard
 ```
-
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-fido2
-solo-python
+fido2 >=0.7.0
+pyscard
 pytest
 pytest-ordering
-solo-python
+solo-python >=0.0.12


### PR DESCRIPTION
We shouldn't advertise pip-installing globally.

Hope `pip install --user` works on Windows, and `pytest` is in whatever is PATH there?