### PR TITLE
Check FIDO2 fields lengths

### DIFF
--- a/tests/standard/fido2/test_resident_key.py
+++ b/tests/standard/fido2/test_resident_key.py
@@ -80,3 +80,28 @@ class TestResidentKey(object):
 
         for x, y in zip(regs, auths):
             verify(x, y, req.cdh)
+
+    def test_rk_maximum_size(self, device, MC_RK_Res):
+        """
+        Check the lengths of the fields according to the FIDO2 spec
+        https://github.com/solokeys/solo/issues/158#issue-426613303
+        https://www.w3.org/TR/webauthn/#dom-publickeycredentialuserentity-displayname
+        """
+        auths = []
+        user_max = generate_user_maximum()
+        req = FidoRequest(MC_RK_Res, user=user_max)
+        resMC = device.sendMC(*req.toMC())
+        resGA = device.sendGA(*req.toGA())
+        credentials = resGA.number_of_credentials
+        assert credentials == 5
+
+        auths.append(resGA)
+        for i in range(credentials - 1):
+            auths.append(device.ctap2.get_next_assertion())
+
+        user_max_GA = auths[-1]
+        verify(resMC, user_max_GA, req.cdh)
+
+        if MC_RK_Res.request.pin_protocol:
+            for y in ("name", "icon", "displayName", "id"):
+                assert user_max_GA.user[y] == user_max[y]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,22 +45,29 @@ def generate_user():
     return {"id": user_id, "name": name, "icon": icon, "displayName": display_name}
 
 
+counter = 1
+
 def generate_user_maximum():
     """
     Generate RK with the maximum lengths of the fields, according to the minimal requirements of the FIDO2 spec
     """
+    global counter
+
     # https://www.w3.org/TR/webauthn/#user-handle
     user_id_length = 64
-    user_id = b'B' * user_id_length
+    user_id = secrets.token_bytes(user_id_length)
 
     # https://www.w3.org/TR/webauthn/#dictionary-pkcredentialentity
     name = " ".join(random.choice(name_list).strip() for i in range(0, 30))
+    name = f'{counter}: {name}'
     icon = "https://www.w3.org/TR/webauthn/" + 'A'*128
     display_name = "Displayed " + name
 
     name = name[:64]
     display_name = display_name[:64]
     icon = icon[:128]
+
+    counter += 1
 
     return {"id": user_id, "name": name, "icon": icon, "displayName": display_name}
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,6 +45,26 @@ def generate_user():
     return {"id": user_id, "name": name, "icon": icon, "displayName": display_name}
 
 
+def generate_user_maximum():
+    """
+    Generate RK with the maximum lengths of the fields, according to the minimal requirements of the FIDO2 spec
+    """
+    # https://www.w3.org/TR/webauthn/#user-handle
+    user_id_length = 64
+    user_id = b'B' * user_id_length
+
+    # https://www.w3.org/TR/webauthn/#dictionary-pkcredentialentity
+    name = " ".join(random.choice(name_list).strip() for i in range(0, 30))
+    icon = "https://www.w3.org/TR/webauthn/" + 'A'*128
+    display_name = "Displayed " + name
+
+    name = name[:64]
+    display_name = display_name[:64]
+    icon = icon[:128]
+
+    return {"id": user_id, "name": name, "icon": icon, "displayName": display_name}
+
+
 def generate_challenge():
     return secrets.token_bytes(32)
 


### PR DESCRIPTION
Add tests for:
- checking the supported minimum required lengths of the RK fields;
- checking the maximum allowed RK assertion list capacity for the given RP.

Related:
https://github.com/solokeys/solo/issues/158#issue-426613303
https://github.com/Nitrokey/nitrokey-fido2-firmware/issues/15

Edit: not tested on hardware yet

- [ ] test on hardware