### PR TITLE
Ctap2 issues

### DIFF
--- a/tests/standard/fido2/test_get_assertion.py
+++ b/tests/standard/fido2/test_get_assertion.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 from fido2.ctap import CtapError
 from fido2.utils import hmac_sha256, sha256
@@ -140,6 +141,12 @@ class TestGetAssertion(object):
                     allow_list=[{"type": b"public-key"}] + GARes.request.allow_list,
                 ).toGA()
             )
+
+    def test_user_presence_option_false(self, device, MCRes, GARes):
+        res = device.sendGA(*FidoRequest(GARes, options = {'up': False}).toGA())
+        verify(MCRes, res, GARes.request.cdh)
+        if '--nfc' not in sys.argv:
+            assert((res.auth_data.flags & 1) == 0)
 
 
 class TestGetAssertionAfterBoot(object):

--- a/tests/standard/fido2/test_get_assertion.py
+++ b/tests/standard/fido2/test_get_assertion.py
@@ -37,6 +37,18 @@ class TestGetAssertion(object):
             device.sendGA(*FidoRequest(allow_list=allow_list).toGA())
         assert e.value.code == CtapError.ERR.NO_CREDENTIALS
 
+    def test_mismatched_rp(self, device, GARes):
+        rp_id = GARes.request.rp['id'][:]
+        rp_name = GARes.request.rp['name'][:]
+        rp_id += '.com'
+
+        mismatch_rp = {'id': rp_id, 'name': rp_name}
+
+        with pytest.raises(CtapError) as e:
+            device.sendGA(*FidoRequest(GARes, rp=mismatch_rp).toGA())
+        assert e.value.code == CtapError.ERR.NO_CREDENTIALS
+
+
     def test_missing_rp(self, device, GARes):
         with pytest.raises(CtapError) as e:
             device.sendGA(*FidoRequest(GARes, rp=None).toGA())

--- a/tests/standard/fido2/user_presence/test_user_presence.py
+++ b/tests/standard/fido2/user_presence/test_user_presence.py
@@ -12,7 +12,6 @@ from tests.utils import *
     reason="Simulation doesn't care about user presence"
 )
 class TestUserPresence(object):
-    @pytest.mark.run(order=1)
     def test_user_presence_instructions(self, MCRes, GARes):
         print()
         print()
@@ -33,6 +32,11 @@ class TestUserPresence(object):
         with pytest.raises(CtapError) as e:
             device.sendGA(*FidoRequest(GARes, timeout=2).toGA())
         assert e.value.code == CtapError.ERR.INVALID_COMMAND
+
+    def test_user_presence_option_false(self, device, MCRes, GARes):
+        print("DO NOT ACTIVATE UP")
+        time.sleep(1)
+        device.sendGA(*FidoRequest(GARes, options = {'up': False}).toGA())
 
     def test_user_presence_permits_only_one_request(self, device, MCRes, GARes):
         print("ACTIVATE UP ONCE")

--- a/tests/standard/fido2/user_presence/test_user_presence.py
+++ b/tests/standard/fido2/user_presence/test_user_presence.py
@@ -33,10 +33,21 @@ class TestUserPresence(object):
             device.sendGA(*FidoRequest(GARes, timeout=2).toGA())
         assert e.value.code == CtapError.ERR.INVALID_COMMAND
 
-    def test_user_presence_option_false(self, device, MCRes, GARes):
+    def test_user_presence_option_false_on_get_assertion(self, device, MCRes, GARes):
         print("DO NOT ACTIVATE UP")
         time.sleep(1)
-        device.sendGA(*FidoRequest(GARes, options = {'up': False}).toGA())
+        device.sendGA(*FidoRequest(GARes, options = {'up': False}, timeout=2).toGA())
+
+    def test_user_presence_option_false_on_make_credential(self, device, MCRes):
+        print("DO NOT ACTIVATE UP")
+        time.sleep(1)
+        with pytest.raises(CtapError) as e:
+            device.sendMC(*FidoRequest(MCRes, options = {'up': False}, timeout=1).toMC())
+        assert e.value.code == CtapError.ERR.INVALID_OPTION
+        with pytest.raises(CtapError) as e:
+            device.sendMC(*FidoRequest(MCRes, options = {'up': True}, timeout=1).toMC())
+        assert e.value.code == CtapError.ERR.INVALID_OPTION
+
 
     def test_user_presence_permits_only_one_request(self, device, MCRes, GARes):
         print("ACTIVATE UP ONCE")

--- a/tests/vendor/solo/test_solo.py
+++ b/tests/vendor/solo/test_solo.py
@@ -42,6 +42,12 @@ class TestSolo(object):
     def test_version(self, solo):
         assert len(solo.solo_version()) == 3
 
+    def test_version_hid(self, solo):
+        data = solo.send_data_hid(0x61, b'')
+        assert len(data) == 3
+        print(f'Version is {data[0]}.{data[1]}.{data[2]}')
+
+
     def test_bootloader_not(self, solo):
         with pytest.raises(ApduError) as e:
             solo.write_flash(0x0, b"1234")


### PR DESCRIPTION
Add tests to verify:
- RpID in request is checked to match credential for non-RK 
- Up=false option in get_assertion allows assertion to pass without UP

https://github.com/solokeys/solo/issues/308
https://github.com/solokeys/solo/issues/306
https://github.com/solokeys/solo/issues/305