### PR TITLE
#27: fido2.utils 0.8 removed Timeout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fido2 >=0.7.3
+fido2 >=0.8
 pyscard
 pytest
 pytest-ordering

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,8 @@ from fido2.ctap import CtapError
 from fido2.ctap1 import CTAP1
 from fido2.ctap2 import ES256, AttestedCredentialData, PinProtocolV1
 from fido2.hid import CtapHidDevice
-from fido2.utils import Timeout, hmac_sha256, sha256
+from fido2.utils import hmac_sha256, sha256
+from solo import helpers
 from tests.utils import *
 
 if "trezor" in sys.argv:
@@ -196,7 +197,7 @@ class TestDevice:
     def send_data(self, cmd, data):
         if not isinstance(data, bytes):
             data = struct.pack("%dB" % len(data), *[ord(x) for x in data])
-        with Timeout(1.0) as event:
+        with helpers.Timeout(1.0) as event:
             return self.dev.call(cmd, data, event)
 
     def send_raw(self, data, cid=None):
@@ -249,7 +250,7 @@ class TestDevice:
         self.dev._dev.cid = cid
 
     def recv_raw(self,):
-        with Timeout(1.0):
+        with helpers.Timeout(1.0):
             cmd, payload = self.dev._dev.InternalRecv()
         return cmd, payload
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import struct
-import time
 import sys
+import time
 
 import pytest
 from fido2.attestation import Attestation
@@ -10,10 +10,9 @@ from fido2.ctap1 import CTAP1
 from fido2.ctap2 import ES256, AttestedCredentialData, PinProtocolV1
 from fido2.hid import CtapHidDevice
 from fido2.utils import Timeout, hmac_sha256, sha256
-
 from tests.utils import *
 
-if 'trezor' in sys.argv:
+if "trezor" in sys.argv:
     from .vendor.trezor.udp_backend import force_udp_backend
 else:
     from solo.fido2 import force_udp_backend
@@ -237,7 +236,7 @@ class TestDevice:
         Send magic nfc reboot sequence for solokey
         """
         data = b"\x12\x56\xab\xf0"
-        header = struct.pack('!BBBBB', 0x00, 0xee, 0x00, 0x00, len(data))
+        header = struct.pack("!BBBBB", 0x00, 0xEE, 0x00, 0x00, len(data))
         resp, sw1, sw2 = self.dev.apdu_exchange(header + data)
         return sw1 == 0x90 and sw2 == 0x00
 
@@ -263,10 +262,19 @@ class TestDevice:
             raise ValueError("Unexpected error: %02x" % data[0])
 
     def register(self, chal, appid, on_keepalive=DeviceSelectCredential(1)):
-        reg_data = _call_polling(0.25, None, on_keepalive, self.ctap1.register, chal, appid)
+        reg_data = _call_polling(
+            0.25, None, on_keepalive, self.ctap1.register, chal, appid
+        )
         return reg_data
 
-    def authenticate(self, chal, appid, key_handle, check_only=False, on_keepalive=DeviceSelectCredential(1)):
+    def authenticate(
+        self,
+        chal,
+        appid,
+        key_handle,
+        check_only=False,
+        on_keepalive=DeviceSelectCredential(1),
+    ):
         auth_data = _call_polling(
             0.25,
             None,


### PR DESCRIPTION
This is one way to fix this.

Passes tests against simulated solo 3.0.1:

```
$ pytest --sim tests/standard --vendor solokeys
...
139 passed, 18 skipped in 11.14s
$ pytest --sim tests/vendor --vendor solokeys
...
6 passed, 3 skipped in 3.21s
```