### PR TITLE
fix missing timeout in fido2 0.8.0+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fido2 >=0.7.3
+fido2 >= 0.8.0
 pyscard
 pytest
 pytest-ordering

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from fido2.ctap import CtapError
 from fido2.ctap1 import CTAP1
 from fido2.ctap2 import ES256, AttestedCredentialData, PinProtocolV1
 from fido2.hid import CtapHidDevice
-from fido2.utils import Timeout, hmac_sha256, sha256
+from fido2.utils import hmac_sha256, sha256
 
 from tests.utils import *
 
@@ -198,6 +198,7 @@ class TestDevice:
         if not isinstance(data, bytes):
             data = struct.pack("%dB" % len(data), *[ord(x) for x in data])
         with Timeout(1.0) as event:
+            event.is_set()
             return self.dev.call(cmd, data, event)
 
     def send_raw(self, data, cid=None):

--- a/tests/standard/fido2/user_presence/test_user_presence.py
+++ b/tests/standard/fido2/user_presence/test_user_presence.py
@@ -30,7 +30,8 @@ class TestUserPresence(object):
     def test_no_user_presence(self, device, MCRes, GARes):
         print("DO NOT ACTIVATE UP")
         with pytest.raises(CtapError) as e:
-            device.sendGA(*FidoRequest(GARes, timeout=2, on_keepalive=None).toGA())
+            with Timeout(2.0) as event:
+                device.sendGA(*FidoRequest(GARes, timeout=event, on_keepalive=None).toGA())
         assert e.value.code == CtapError.ERR.KEEPALIVE_CANCEL
 
     @pytest.mark.skipif(not 'trezor' in sys.argv, reason="Only Trezor supports decline.")
@@ -43,16 +44,19 @@ class TestUserPresence(object):
     def test_user_presence_option_false_on_get_assertion(self, device, MCRes, GARes):
         print("DO NOT ACTIVATE UP")
         time.sleep(1)
-        device.sendGA(*FidoRequest(GARes, options = {'up': False}, timeout=2).toGA())
+        with Timeout(2.0) as event:
+            device.sendGA(*FidoRequest(GARes, options = {'up': False}, timeout=event).toGA())
 
     def test_user_presence_option_false_on_make_credential(self, device, MCRes):
         print("DO NOT ACTIVATE UP")
         time.sleep(1)
         with pytest.raises(CtapError) as e:
-            device.sendMC(*FidoRequest(MCRes, options = {'up': False}, timeout=1).toMC())
+            with Timeout(1.0) as event:
+                device.sendMC(*FidoRequest(MCRes, options = {'up': False}, timeout=event).toMC())
         assert e.value.code == CtapError.ERR.INVALID_OPTION
         with pytest.raises(CtapError) as e:
-            device.sendMC(*FidoRequest(MCRes, options = {'up': True}, timeout=1).toMC())
+            with Timeout(1.0) as event:
+                device.sendMC(*FidoRequest(MCRes, options = {'up': True}, timeout=event).toMC())
         assert e.value.code == CtapError.ERR.INVALID_OPTION
 
 
@@ -61,5 +65,6 @@ class TestUserPresence(object):
         device.sendGA(*FidoRequest(GARes).toGA())
 
         with pytest.raises(CtapError) as e:
-            device.sendGA(*FidoRequest(GARes, timeout=1, on_keepalive=None).toGA())
+            with Timeout(1.0) as event:
+                device.sendGA(*FidoRequest(GARes, timeout=event, on_keepalive=None).toGA())
         assert e.value.code == CtapError.ERR.KEEPALIVE_CANCEL

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,8 @@ import math
 import random
 import secrets
 import sys
+from threading import Event, Timer
+from numbers import Number
 
 from fido2.ctap2 import ES256, AttestedCredentialData, PinProtocolV1
 from fido2.utils import hmac_sha256, sha256
@@ -185,3 +187,59 @@ class FidoRequest:
         ]
 
         return args + self.get_optional_args()
+
+
+# Timeout from:
+#   https://github.com/Yubico/python-fido2/blob/f1dc028d6158e1d6d51558f72055c65717519b9b/fido2/utils.py
+# Copyright (c) 2013 Yubico AB
+# All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or
+#   without modification, are permitted provided that the following
+#   conditions are met:
+#
+#    1. Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#    2. Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+class Timeout(object):
+    """Utility class for adding a timeout to an event.
+    :param time_or_event: A number, in seconds, or a threading.Event object.
+    :ivar event: The Event associated with the Timeout.
+    :ivar timer: The Timer associated with the Timeout, if any.
+    """
+
+    def __init__(self, time_or_event):
+
+        if isinstance(time_or_event, Number):
+            self.event = Event()
+            self.timer = Timer(time_or_event, self.event.set)
+        else:
+            self.event = time_or_event
+            self.timer = None
+
+    def __enter__(self):
+        if self.timer:
+            self.timer.start()
+        return self.event
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.timer:
+            self.timer.cancel()
+            self.timer.join()


### PR DESCRIPTION
Patches the use of Timeout event object that is no longer in 0.8.0+ of fido2 library.