### PR TITLE
fix multiple values for argument 'options'

### DIFF
--- a/tests/standard/fido2/test_getinfo.py
+++ b/tests/standard/fido2/test_getinfo.py
@@ -29,7 +29,7 @@ def test_Check_options_field(info):
 def test_Check_uv_option(device, info):
     if "uv" in info.options:
         if info.options["uv"]:
-            device.sendMC(*FidoRequest().toMC(), options={"uv": True})
+            device.sendMC(*FidoRequest(options={"uv": True}).toMC())
 
 
 def test_Check_up_option(device, info):


### PR DESCRIPTION
When running `tests/standard/fido2/test_getinfo.py` on Python 3.8, the test fails with:

    TypeError: make_credential() got multiple values for argument 'options'

Move `options` into `FidoRequest` parameters in order to fix the invocation of `device.sendMC`.