### PR TITLE
Make assertion verification not require field credential

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -33,7 +33,8 @@ def verify(reg, auth, cdh=None):
         cdh = auth.request.cdh
     auth.verify(cdh, credential_data.public_key)
     assert auth.auth_data.rp_id_hash == reg.auth_data.rp_id_hash
-    assert auth.credential["id"] == reg.auth_data.credential_data.credential_id
+    if auth.credential is not None:
+        assert auth.credential["id"] == reg.auth_data.credential_data.credential_id
 
 
 def generate_rp():


### PR DESCRIPTION
The FIDO2 standard (https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#authenticatorGetAssertion) states that the field `credential` "may be omitted if the allowList has
exactly one Credential."

Allow `auth.credential` to be `None`.