### PR TITLE
Fix cbor cred protect

### DIFF
--- a/tests/standard/fido2/__init__.py
+++ b/tests/standard/fido2/__init__.py
@@ -4,6 +4,7 @@ from functools import cmp_to_key
 import tests
 from fido2 import cbor
 
+
 def cbor_key_to_representative(key):
     if isinstance(key, int):
         if key >= 0:
@@ -58,11 +59,23 @@ def TestCborKeysSorted(cbor_obj):
 
     for i in range(len(l)):
 
-        if not isinstance(l[i], (str, int)):
+        if isinstance(cbor_obj, dict) and not isinstance(l[i], (str, int)):
             raise ValueError(f"Cbor map key {l[i]} must be int or str for CTAP2")
 
         if l[i] != l_sorted[i]:
             raise ValueError(f"Cbor map item {i}: {l[i]} is out of order")
+
+        # value = None
+        if isinstance(cbor_obj, dict):
+            value = cbor_obj[l[i]]
+        else:
+            value = l[i]
+
+        if isinstance(value, dict):
+            TestCborKeysSorted(cbor_obj[l[i]])
+
+        elif isinstance(value, list):
+            TestCborKeysSorted(cbor_obj[l[i]])
 
     return l
 

--- a/tests/standard/fido2/extensions/test_cred_protect.py
+++ b/tests/standard/fido2/extensions/test_cred_protect.py
@@ -1,0 +1,33 @@
+import pytest
+
+from tests.utils import FidoRequest 
+
+
+@pytest.fixture(scope="class")
+def MCCredProtect(
+    resetDevice,
+):
+    req = FidoRequest(extensions={"credProtect": 1})
+    res = resetDevice.sendMC(*req.toMC())
+    setattr(res, "request", req)
+    return res
+
+
+class TestCredProtect(object):
+    def test_credprotect_make_credential(self, MCCredProtect):
+        assert MCCredProtect.auth_data.extensions
+        assert "credProtect" in MCCredProtect.auth_data.extensions
+        assert MCCredProtect.auth_data.extensions["credProtect"] == True
+
+    def test_hmac_secret_and_credProtect_make_credential(
+        self, resetDevice, MCCredProtect
+    ):
+
+        req = FidoRequest(extensions={"credProtect": 1, "hmac-secret": True})
+        res = resetDevice.sendMC(*req.toMC())
+        setattr(res, "request", req)
+
+        for ext in ["credProtect", "hmac-secret"]:
+            assert res.auth_data.extensions
+            assert ext in res.auth_data.extensions
+            assert res.auth_data.extensions[ext] == True


### PR DESCRIPTION
Adds more test coverage for cbor.  Previously cbor was validated at a single depth, now it recurses through all cbor and validates it.

Also test credProtect extension, and credProtect+hmac-secret at the same time.