### PR TITLE
Change expected error codes of some tests

### DIFF
--- a/tests/standard/fido2/pin/test_pin.py
+++ b/tests/standard/fido2/pin/test_pin.py
@@ -60,7 +60,7 @@ class TestPin(object):
         with pytest.raises(CtapError) as e:
             device.client.pin_protocol.set_pin('1234')
 
-        assert e.value.code == CtapError.ERR.NOT_ALLOWED
+        assert e.value.code == CtapError.ERR.PIN_AUTH_INVALID
 
 
     def test_get_key_agreement_fields(self, CPRes):
@@ -99,11 +99,11 @@ class TestPin(object):
     def test_zero_length_pin_auth(self, device, SetPinRes):
         with pytest.raises(CtapError) as e:
             reg = device.sendMC(*FidoRequest(SetPinRes, pin_auth=b"").toMC())
-        assert e.value.code == CtapError.ERR.PIN_AUTH_INVALID
+        assert e.value.code == CtapError.ERR.PIN_INVALID
 
         with pytest.raises(CtapError) as e:
             reg = device.sendGA(*FidoRequest(SetPinRes, pin_auth=b"").toGA())
-        assert e.value.code == CtapError.ERR.PIN_AUTH_INVALID
+        assert e.value.code == CtapError.ERR.PIN_INVALID
 
     def test_make_credential_no_pin(self, device, SetPinRes):
         with pytest.raises(CtapError) as e:

--- a/tests/standard/fido2/user_presence/test_user_presence.py
+++ b/tests/standard/fido2/user_presence/test_user_presence.py
@@ -34,7 +34,7 @@ class TestUserPresence(object):
                 device.sendGA(
                     *FidoRequest(GARes, timeout=event, on_keepalive=None).toGA()
                 )
-        assert e.value.code == CtapError.ERR.KEEPALIVE_CANCEL
+        assert e.value.code == CtapError.ERR.OPERATION_DENIED
 
     @pytest.mark.skipif(
         not "trezor" in sys.argv, reason="Only Trezor supports decline."


### PR DESCRIPTION
This PR adjusts the expected error codes of some tests based on the [issue](https://github.com/solokeys/fido2-tests/issues/55) I opened a few weeks ago.

This PR only adjusts the expected error codes of tests where the correct error code is clearly mentioned in the CTAP spec.